### PR TITLE
Awandersleben05/pat 254 patch hover documentation gifs not accessible

### DIFF
--- a/src/components/EditorPane/CodeEditor/HoverTooltip/component.tsx
+++ b/src/components/EditorPane/CodeEditor/HoverTooltip/component.tsx
@@ -1,0 +1,21 @@
+import { Typography } from "@mui/material";
+import React from "react";
+
+type HoverTooltipProps = {
+    declare: string,
+    descript: string,
+    exampleCode: string,
+    imgSrc: string
+};
+export const HoverTooltip = (props:HoverTooltipProps) => {
+
+  return (
+    <div style={{ width: 300 }}>
+        <Typography variant="body1">{props.declare}</Typography>
+        <Typography variant="body2">{props.descript} </Typography>
+        <Typography variant="body2">Exmaple: {props.exampleCode}</Typography>
+        <img src={props.imgSrc} onError={({currentTarget})=> {currentTarget.src = "https://firebasestorage.googleapis.com/v0/b/patch-271d1.appspot.com/o/gifs%2Fshow.gif?alt=media"}} width={300}/>
+    </div>
+  );
+};
+export default HoverTooltip;

--- a/src/components/EditorPane/CodeEditor/HoverTooltip/component.tsx
+++ b/src/components/EditorPane/CodeEditor/HoverTooltip/component.tsx
@@ -14,7 +14,7 @@ export const HoverTooltip = (props:HoverTooltipProps) => {
         <Typography variant="body1">{props.declare}</Typography>
         <Typography variant="body2">{props.descript} </Typography>
         <Typography variant="body2">Exmaple: {props.exampleCode}</Typography>
-        <img src={props.imgSrc} onError={({currentTarget})=> {currentTarget.src = "https://firebasestorage.googleapis.com/v0/b/patch-271d1.appspot.com/o/gifs%2Fshow.gif?alt=media"}} width={300}/>
+        <img src={props.imgSrc} alt="" width={300}/>
     </div>
   );
 };

--- a/src/components/EditorPane/CodeEditor/HoverTooltip/component.tsx
+++ b/src/components/EditorPane/CodeEditor/HoverTooltip/component.tsx
@@ -2,19 +2,29 @@ import { Typography } from "@mui/material";
 import React from "react";
 
 type HoverTooltipProps = {
-    declare: string,
-    descript: string,
-    exampleCode: string,
-    imgSrc: string
+  declare: string;
+  descript: string;
+  exampleCode: string;
+  imgSrc: string;
 };
-export const HoverTooltip = (props:HoverTooltipProps) => {
-
+export const HoverTooltip = (props: HoverTooltipProps) => {
   return (
-    <div style={{ width: 300 }}>
-        <Typography variant="body1">{props.declare}</Typography>
-        <Typography variant="body2">{props.descript} </Typography>
-        <Typography variant="body2">Exmaple: {props.exampleCode}</Typography>
-        <img src={props.imgSrc} alt="" width={300}/>
+    <div
+      style={{
+        width: 300,
+        border: "1px solid rgba(255, 255, 255, 0.1)",
+        borderRadius: "5px",
+        padding: "5px",
+      }}
+    >
+      <Typography variant="body1">{props.declare}</Typography>
+      <Typography variant="body2">{props.descript} </Typography>
+      <Typography variant="body2">Example: {props.exampleCode}</Typography>
+      {props.imgSrc !== "" ? (
+        <img src={props.imgSrc} alt="" width={300} height={200} />
+      ) : (
+        <></>
+      )}
     </div>
   );
 };

--- a/src/components/EditorPane/CodeEditor/HoverTooltip/component.tsx
+++ b/src/components/EditorPane/CodeEditor/HoverTooltip/component.tsx
@@ -1,5 +1,5 @@
 import { Typography } from "@mui/material";
-import React from "react";
+import React, { useState } from "react";
 
 type HoverTooltipProps = {
   declare: string;
@@ -7,7 +7,11 @@ type HoverTooltipProps = {
   exampleCode: string;
   imgSrc: string;
 };
+
 export const HoverTooltip = (props: HoverTooltipProps) => {
+  // Step 2: Initialize showImage state
+  const [showImage, setShowImage] = useState(true);
+
   return (
     <div
       style={{
@@ -18,14 +22,21 @@ export const HoverTooltip = (props: HoverTooltipProps) => {
       }}
     >
       <Typography variant="body1">{props.declare}</Typography>
-      <Typography variant="body2">{props.descript} </Typography>
+      <Typography variant="body2">{props.descript}</Typography>
       <Typography variant="body2">Example: {props.exampleCode}</Typography>
-      {props.imgSrc !== "" ? (
-        <img src={props.imgSrc} alt="" width={300} height={200} />
+      {/* Step 4: Conditionally render the img tag */}
+      {props.imgSrc !== "" && showImage ? (
+        <img
+          src={props.imgSrc}
+          alt="Patch Function"
+          width={300}
+          height={200}
+          // Step 3: onError event handler
+          onError={() => setShowImage(false)}
+        />
       ) : (
         <></>
       )}
     </div>
   );
 };
-export default HoverTooltip;

--- a/src/components/EditorPane/CodeEditor/HoverTooltip/index.ts
+++ b/src/components/EditorPane/CodeEditor/HoverTooltip/index.ts
@@ -1,0 +1,1 @@
+export * from './component';

--- a/src/components/EditorPane/CodeEditor/PatchCodeMirror/component.tsx
+++ b/src/components/EditorPane/CodeEditor/PatchCodeMirror/component.tsx
@@ -64,15 +64,16 @@ const PatchCodeMirror = ({
           "https://firebasestorage.googleapis.com/v0/b/patch-271d1.appspot.com/o/gifs%2F" +
           funName +
           ".gif?alt=media";
-        imgSrc = funName == "" ? "" : imgSrc;
-        root.render(
-          <HoverTooltip
-            declare={functionDeclaration}
-            descript={description}
-            exampleCode={exampleCode}
-            imgSrc={imgSrc}
-          />
-        );
+        if (funName != "") {
+          root.render(
+            <HoverTooltip
+              declare={functionDeclaration}
+              descript={description}
+              exampleCode={exampleCode}
+              imgSrc={imgSrc}
+            />
+          );
+        }
         return { dom };
       },
     };

--- a/src/components/EditorPane/CodeEditor/PatchCodeMirror/component.tsx
+++ b/src/components/EditorPane/CodeEditor/PatchCodeMirror/component.tsx
@@ -8,9 +8,9 @@ import { indentationMarkers } from "@replit/codemirror-indentation-markers";
 import { Thread } from "../../types";
 import usePatchStore from "../../../../store";
 import { useRuntimeDiagnostics } from "../../../../hooks/useRuntimeDiagnostics";
-import {hoverTooltip} from "@codemirror/view";
-import patchAPI from "../../../../assets/patch-api.json"
-import { createRoot } from 'react-dom/client'
+import { hoverTooltip } from "@codemirror/view";
+import patchAPI from "../../../../assets/patch-api.json";
+import { createRoot } from "react-dom/client";
 import { HoverTooltip } from "../HoverTooltip";
 
 type PatchCodeMirrorProps = {
@@ -46,34 +46,37 @@ const PatchCodeMirror = ({
       end,
       above: true,
       create(view) {
-        const dom = document.createElement("div")
+        const dom = document.createElement("div");
         const root = createRoot(dom);
         let funName = "";
         let functionDeclaration = "";
         let description = "";
         let exampleCode = "";
-        patchAPI["patch-functions"].forEach(function(x){
+        patchAPI["patch-functions"].forEach(function (x) {
           if (x["name"] == text.slice(start - from, end - from)) {
             funName = x["name"];
             functionDeclaration = x["name"] + getParamText(x["parameters"]);
             description = x["description"];
             exampleCode = x["exampleUsage"];
           }
-      });
-      let imgSrc = "https://firebasestorage.googleapis.com/v0/b/patch-271d1.appspot.com/o/gifs%2F" +
-            funName +
-            ".gif?alt=media";
-      if(funName != "") {
-        root.render(<HoverTooltip
-        declare = {functionDeclaration}
-        descript = {description}
-        exampleCode = {exampleCode} 
-        imgSrc = {imgSrc}/>);
-      }
-        return {dom}
-      }
-    }
-  })
+        });
+        let imgSrc =
+          "https://firebasestorage.googleapis.com/v0/b/patch-271d1.appspot.com/o/gifs%2F" +
+          funName +
+          ".gif?alt=media";
+        imgSrc = funName == "" ? "" : imgSrc;
+        root.render(
+          <HoverTooltip
+            declare={functionDeclaration}
+            descript={description}
+            exampleCode={exampleCode}
+            imgSrc={imgSrc}
+          />
+        );
+        return { dom };
+      },
+    };
+  });
 
   useEffect(() => {
     setCodemirrorRef(thread.id, codemirrorRef);


### PR DESCRIPTION
Made hover tooltips a react component. I'm assuming the font problem meant to use the MUI font and if so that should be fixed? I left the same format Elliot had for if there is no gif for the function then show the show gif but I can also leave it blank it you would like (UPDATE: newest commit leaves it blank). Also let me know if you want me to change the style at all (design is not my strength)
<img width="300" alt="Screenshot 2024-06-24 at 10 20 20 AM" src="https://github.com/BX-Coding/patch-ide/assets/78870469/156e58e1-605c-422c-926c-27c4ac1736a3">
